### PR TITLE
Fix : 게시글, 댓글 조회 수정

### DIFF
--- a/groove-api/build.gradle.kts
+++ b/groove-api/build.gradle.kts
@@ -28,4 +28,5 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-security:$springDocVersion")
     implementation(project(":groove-security:spring-security"))
     implementation(project(":groove-security:auth-api"))
+    implementation(project(":groove-security:auth"))
 }

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentCreator.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentCreator.java
@@ -19,7 +19,7 @@ public class CommentCreator {
     @Transactional
     public Comment createComment(String content, Long parentId, Long userId, Long postId) {
         try {
-            var entity = commentRepository.save(new CommentEntity(content, false, parentId, userId, postId));
+            var entity = commentRepository.save(new CommentEntity(content, parentId, userId, postId));
             PostEntity post = postRepository.getById(postId);
             post.setCommentCount(post.getCommentCount() + 1);
             return new Comment(entity);

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentCreator.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentCreator.java
@@ -1,20 +1,27 @@
 package org.bogus.groove.domain.comment;
 
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.bogus.groove.common.exception.ErrorType;
 import org.bogus.groove.common.exception.InternalServerException;
 import org.bogus.groove.storage.entity.CommentEntity;
+import org.bogus.groove.storage.entity.PostEntity;
 import org.bogus.groove.storage.repository.CommentRepository;
+import org.bogus.groove.storage.repository.PostRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class CommentCreator {
     private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
 
+    @Transactional
     public Comment createComment(String content, Long parentId, Long userId, Long postId) {
         try {
             var entity = commentRepository.save(new CommentEntity(content, false, parentId, userId, postId));
+            PostEntity post = postRepository.getById(postId);
+            post.setCommentCount(post.getCommentCount() + 1);
             return new Comment(entity);
         } catch (IllegalArgumentException e) {
             throw new InternalServerException(ErrorType.FAILED_TO_CREATE_COMMENT);

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentDeleter.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentDeleter.java
@@ -1,10 +1,12 @@
 package org.bogus.groove.domain.comment;
 
+import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.bogus.groove.common.exception.ErrorType;
 import org.bogus.groove.common.exception.NotFoundException;
 import org.bogus.groove.common.exception.UnauthorizedException;
+import org.bogus.groove.storage.entity.CommentEntity;
 import org.bogus.groove.storage.entity.PostEntity;
 import org.bogus.groove.storage.repository.CommentRepository;
 import org.bogus.groove.storage.repository.PostRepository;
@@ -23,6 +25,11 @@ public class CommentDeleter {
             entity.setDeleted(true);
             PostEntity post = postRepository.getById(entity.getPostId());
             post.setCommentCount(post.getCommentCount() - 1);
+            List<CommentEntity> reComments = commentRepository.findAllByParentIdAndIsDeletedFalse(entity.getId());
+            for (CommentEntity reComment : reComments) {
+                reComment.setDeleted(true);
+                post.setCommentCount(post.getCommentCount() - 1);
+            }
         } else {
             throw new UnauthorizedException(ErrorType.FORBIDDEN_NOT_ENOUGH_AUTHORITY);
         }

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentDeleter.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentDeleter.java
@@ -5,19 +5,24 @@ import lombok.RequiredArgsConstructor;
 import org.bogus.groove.common.exception.ErrorType;
 import org.bogus.groove.common.exception.NotFoundException;
 import org.bogus.groove.common.exception.UnauthorizedException;
+import org.bogus.groove.storage.entity.PostEntity;
 import org.bogus.groove.storage.repository.CommentRepository;
+import org.bogus.groove.storage.repository.PostRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class CommentDeleter {
     private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
 
     @Transactional
     public void deleteComment(Long userId, Long commentId) {
         var entity = commentRepository.findById(commentId).orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_COMMENT));
         if (entity.getUserId() == userId) {
             entity.setDeleted(true);
+            PostEntity post = postRepository.getById(entity.getPostId());
+            post.setCommentCount(post.getCommentCount() - 1);
         } else {
             throw new UnauthorizedException(ErrorType.FORBIDDEN_NOT_ENOUGH_AUTHORITY);
         }

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentGetResult.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentGetResult.java
@@ -28,6 +28,6 @@ public class CommentGetResult {
 
     public CommentGetResult(Comment comment, List<Comment> reComments) {
         this(comment);
-        this.reComments = reComments.stream().map(reComment -> new CommentGetResult(reComment)).collect(Collectors.toList());
+        this.reComments = reComments.stream().map(CommentGetResult::new).collect(Collectors.toList());
     }
 }

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentGetResult.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentGetResult.java
@@ -13,21 +13,24 @@ public class CommentGetResult {
     private boolean isDeleted;
     private Long parentId;
     private Long userId;
+    private String nickName;
     private Long postId;
     private List<CommentGetResult> reComments;
 
-    public CommentGetResult(Comment comment) {
+    public CommentGetResult(Comment comment, String nickName) {
         this.id = comment.getId();
         this.createdAt = comment.getCreatedAt();
         this.content = comment.getContent();
         this.isDeleted = comment.isDeleted();
         this.parentId = comment.getParentId();
         this.userId = comment.getUserId();
+        this.nickName = nickName;
         this.postId = comment.getPostId();
     }
 
-    public CommentGetResult(Comment comment, List<Comment> reComments) {
-        this(comment);
-        this.reComments = reComments.stream().map(CommentGetResult::new).collect(Collectors.toList());
+    public CommentGetResult(Comment comment, String nickName, List<CommentGetResult> reComments) {
+        this(comment, nickName);
+        this.nickName = nickName;
+        this.reComments = reComments;
     }
 }

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentGetResult.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentGetResult.java
@@ -2,7 +2,6 @@ package org.bogus.groove.domain.comment;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentReader.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentReader.java
@@ -17,13 +17,13 @@ public class CommentReader {
         checkPostIsExist(postId);
         return commentRepository.findAllByPostIdAndIsDeletedFalse(postId).stream().filter(entity -> entity.getId() == entity.getParentId())
             .map(
-                entity -> new Comment(entity)).collect(Collectors.toList());
+                Comment::new).collect(Collectors.toList());
     }
 
     public List<Comment> readAllPostReComment(Long commentId) {
         return commentRepository.findAllByParentIdAndIsDeletedFalse(commentId).stream()
             .filter(entity -> entity.getId() != entity.getParentId())
-            .map(entity -> new Comment(entity)).collect(Collectors.toList());
+            .map(Comment::new).collect(Collectors.toList());
     }
 
     public Integer countPostComment(Long postId) {

--- a/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentService.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/comment/CommentService.java
@@ -3,6 +3,7 @@ package org.bogus.groove.domain.comment;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.bogus.groove.domain.user.UserReader;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,6 +13,7 @@ public class CommentService {
     private final CommentReader commentReader;
     private final CommentUpdater commentUpdater;
     private final CommentDeleter commentDeleter;
+    private final UserReader userReader;
 
     public Comment createComment(String content, Long parentId, Long userId, Long postId) {
         return commentCreator.createComment(content, parentId, userId, postId);
@@ -19,8 +21,11 @@ public class CommentService {
 
     public List<CommentGetResult> getCommentList(Long postId) {
         return commentReader.readAllPostComment(postId).stream()
-            .map(comment -> new CommentGetResult(comment, commentReader.readAllPostReComment(
-                comment.getId()))).collect(
+            .map(comment -> new CommentGetResult(comment, userReader.read(comment.getUserId()).getNickname(),
+                commentReader.readAllPostReComment(
+                        comment.getId()).stream()
+                    .map(reComment -> new CommentGetResult(reComment, userReader.read(reComment.getUserId()).getNickname())).collect(
+                        Collectors.toList()))).collect(
                 Collectors.toList());
     }
 

--- a/groove-api/src/main/java/org/bogus/groove/domain/like/LikeCreator.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/like/LikeCreator.java
@@ -1,17 +1,22 @@
 package org.bogus.groove.domain.like;
 
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.bogus.groove.common.exception.ErrorType;
 import org.bogus.groove.common.exception.InternalServerException;
 import org.bogus.groove.storage.entity.LikeEntity;
+import org.bogus.groove.storage.entity.PostEntity;
 import org.bogus.groove.storage.repository.LikeRepository;
+import org.bogus.groove.storage.repository.PostRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class LikeCreator {
     private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
 
+    @Transactional
     public void create(Long userId, Long postId) {
         try {
             var entity = likeRepository.findByUserIdAndPostId(userId, postId);
@@ -20,6 +25,8 @@ public class LikeCreator {
                 throw new InternalServerException(ErrorType.ALREADY_LIKE_POST);
             } else {
                 likeRepository.save(new LikeEntity(userId, postId));
+                PostEntity post = postRepository.getById(postId);
+                post.setLikeCount(post.getLikeCount() + 1);
             }
         } catch (IllegalArgumentException e) {
             throw new InternalServerException(ErrorType.FAILED_TO_LIKE_POST);

--- a/groove-api/src/main/java/org/bogus/groove/domain/like/LikeDeleter.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/like/LikeDeleter.java
@@ -1,23 +1,30 @@
 package org.bogus.groove.domain.like;
 
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.bogus.groove.common.exception.ErrorType;
 import org.bogus.groove.common.exception.NotFoundException;
 import org.bogus.groove.common.exception.UnauthorizedException;
+import org.bogus.groove.storage.entity.PostEntity;
 import org.bogus.groove.storage.repository.LikeRepository;
+import org.bogus.groove.storage.repository.PostRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class LikeDeleter {
     private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
 
+    @Transactional
     public void delete(Long userId, Long postId) {
         var entity =
             likeRepository.findByUserIdAndPostId(userId, postId).orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_LIKE));
 
         if (userId == entity.getUserId() && postId == entity.getPostId()) {
             likeRepository.delete(entity);
+            PostEntity post = postRepository.getById(postId);
+            post.setLikeCount(post.getLikeCount() - 1);
         } else {
             throw new UnauthorizedException(ErrorType.FORBIDDEN_NOT_ENOUGH_AUTHORITY);
         }

--- a/groove-api/src/main/java/org/bogus/groove/domain/like/LikeReader.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/like/LikeReader.java
@@ -12,7 +12,7 @@ public class LikeReader {
     private final LikeRepository likeRepository;
 
     public List<Like> likeList(Long userId) {
-        return likeRepository.findByUserId(userId).stream().map(entity -> new Like(entity)).collect(Collectors.toList());
+        return likeRepository.findByUserId(userId).stream().map(Like::new).collect(Collectors.toList());
     }
 
     public boolean checkLike(Long userId, Long postId) {

--- a/groove-api/src/main/java/org/bogus/groove/domain/post/Post.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/post/Post.java
@@ -18,6 +18,7 @@ public class Post {
     private Integer likeCount;
     private Integer commentCount;
     private Long userId;
+    private Long categoryId;
 
     public Post(PostEntity entity) {
         this.id = entity.getId();
@@ -28,5 +29,6 @@ public class Post {
         this.likeCount = entity.getLikeCount();
         this.commentCount = entity.getCommentCount();
         this.userId = entity.getUserId();
+        this.categoryId = entity.getCategoryId();
     }
 }

--- a/groove-api/src/main/java/org/bogus/groove/domain/post/PostCreator.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/post/PostCreator.java
@@ -14,7 +14,7 @@ public class PostCreator {
 
     public Post createPost(String title, String content, Long userId, Long categoryId) {
         try {
-            var entity = postRepository.save(new PostEntity(title, content, false, userId, categoryId));
+            var entity = postRepository.save(new PostEntity(title, content, userId, categoryId));
             return new Post(entity);
         } catch (IllegalArgumentException e) {
             throw new InternalServerException(ErrorType.FAILED_TO_CREATE_POST);

--- a/groove-api/src/main/java/org/bogus/groove/domain/post/PostDeleter.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/post/PostDeleter.java
@@ -1,10 +1,13 @@
 package org.bogus.groove.domain.post;
 
+import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.bogus.groove.common.exception.ErrorType;
 import org.bogus.groove.common.exception.NotFoundException;
 import org.bogus.groove.common.exception.UnauthorizedException;
+import org.bogus.groove.storage.entity.CommentEntity;
+import org.bogus.groove.storage.repository.CommentRepository;
 import org.bogus.groove.storage.repository.PostRepository;
 import org.springframework.stereotype.Component;
 
@@ -12,12 +15,17 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostDeleter {
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public void deletePost(Long userId, Long postId) {
         var entity = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_POST));
         if (entity.getUserId() == userId) {
             entity.setDeleted(true);
+            List<CommentEntity> comments = commentRepository.findAllByPostIdAndIsDeletedFalse(postId);
+            for (CommentEntity comment : comments) {
+                comment.setDeleted(true);
+            }
         } else {
             throw new UnauthorizedException(ErrorType.FORBIDDEN_NOT_ENOUGH_AUTHORITY);
         }

--- a/groove-api/src/main/java/org/bogus/groove/domain/post/PostGetResult.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/post/PostGetResult.java
@@ -8,19 +8,22 @@ public class PostGetResult {
     private String title;
     private String content;
     private Long userId;
-    //private String nickName;
+    private String nickName;
     //private String profileImg;
     private boolean likeFlag;
     private Integer likeCount;
     private Integer commentCount;
+    private Long categoryId;
 
-    public PostGetResult(Post post, boolean likeFlag, Integer likeCount, Integer commentCount) {
+    public PostGetResult(Post post, String nickName, boolean likeFlag) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.userId = post.getUserId();
+        this.nickName = nickName;
         this.likeFlag = likeFlag;
-        this.likeCount = likeCount;
-        this.commentCount = commentCount;
+        this.likeCount = post.getLikeCount();
+        this.commentCount = post.getCommentCount();
+        this.categoryId = post.getCategoryId();
     }
 }

--- a/groove-api/src/main/java/org/bogus/groove/domain/post/PostService.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/post/PostService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.bogus.groove.common.enumeration.SortOrderType;
-import org.bogus.groove.domain.comment.CommentReader;
 import org.bogus.groove.domain.like.Like;
 import org.bogus.groove.domain.like.LikeReader;
 import org.bogus.groove.domain.user.User;

--- a/groove-api/src/main/java/org/bogus/groove/domain/post/PostService.java
+++ b/groove-api/src/main/java/org/bogus/groove/domain/post/PostService.java
@@ -7,6 +7,8 @@ import org.bogus.groove.common.enumeration.SortOrderType;
 import org.bogus.groove.domain.comment.CommentReader;
 import org.bogus.groove.domain.like.Like;
 import org.bogus.groove.domain.like.LikeReader;
+import org.bogus.groove.domain.user.User;
+import org.bogus.groove.domain.user.UserReader;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
@@ -20,30 +22,29 @@ public class PostService {
     private final PostUpdater postUpdater;
     private final PostDeleter postDeleter;
     private final LikeReader likeReader;
-    private final CommentReader commentReader;
+    private final UserReader userReader;
 
     public Post createPost(String title, String content, Long userId, Long categoryId) {
         return postCreator.createPost(title, content, userId, categoryId);
     }
 
     public Slice<PostGetResult> getPostList(Long userId, Long categoryId, int page, int size, SortOrderType sortOrderType, String word) {
+        User user = userReader.read(userId);
         List<Like> likeList = likeReader.likeList(userId);
         var posts = postReader.readAllPosts(categoryId, page, size, sortOrderType, word);
         return new SliceImpl<>(
             posts.map(
-                post -> new PostGetResult(post,
-                    !likeList.stream().filter(like -> like.getPostId() == post.getId()).collect(Collectors.toList()).isEmpty(),
-                    likeReader.countPostLike(post.getId()),
-                    commentReader.countPostComment(post.getId()))).toList(),
+                post -> new PostGetResult(post, user.getNickname(),
+                    !likeList.stream().filter(like -> like.getPostId() == post.getId()).collect(Collectors.toList()).isEmpty())).toList(),
             posts.getPageable(),
             posts.hasNext()
         );
     }
 
     public PostGetDetailResult getPost(Long userId, Long postId) {
+        User user = userReader.read(userId);
         Post post = postReader.readPost(postId);
-        PostGetResult result = new PostGetResult(post, likeReader.checkLike(userId, postId), likeReader.countPostLike(postId),
-            commentReader.countPostComment(postId));
+        PostGetResult result = new PostGetResult(post, user.getNickname(), likeReader.checkLike(userId, postId));
         PostGetDetailResult postDetail = new PostGetDetailResult(result, post.getCreatedAt());
         return postDetail;
     }

--- a/groove-api/src/main/java/org/bogus/groove/endpoint/comment/CommentController.java
+++ b/groove-api/src/main/java/org/bogus/groove/endpoint/comment/CommentController.java
@@ -38,7 +38,7 @@ public class CommentController {
     @Operation(summary = "댓글 리스트 조회")
     @GetMapping("/post/{postId}/comment")
     public CommonResponse<List<CommentResponse>> getCommentList(@PathVariable Long postId) {
-        return CommonResponse.success(commentService.getCommentList(postId).stream().map(comment -> new CommentResponse(comment)).collect(
+        return CommonResponse.success(commentService.getCommentList(postId).stream().map(CommentResponse::new).collect(
             Collectors.toList()));
     }
 

--- a/groove-api/src/main/java/org/bogus/groove/endpoint/comment/CommentResponse.java
+++ b/groove-api/src/main/java/org/bogus/groove/endpoint/comment/CommentResponse.java
@@ -17,6 +17,7 @@ public class CommentResponse {
     private String content;
     private Long parentId;
     private Long userId;
+    private String nickName;
     private Long postId;
     private List<CommentResponse> reComments;
 
@@ -26,6 +27,7 @@ public class CommentResponse {
         this.content = comment.getContent();
         this.parentId = comment.getParentId();
         this.userId = comment.getUserId();
+        this.nickName = comment.getNickName();
         this.postId = comment.getPostId();
         this.reComments = Optional.ofNullable(comment.getReComments()).orElseGet(Collections::emptyList).stream()
             .map(reComment -> new CommentResponse(reComment)).collect(

--- a/groove-api/src/main/java/org/bogus/groove/endpoint/post/PostDetailResponse.java
+++ b/groove-api/src/main/java/org/bogus/groove/endpoint/post/PostDetailResponse.java
@@ -11,9 +11,11 @@ public class PostDetailResponse {
     private String title;
     private String content;
     private Long userId;
+    private String nickName;
     private boolean likeFlag;
     private Integer likeCount;
     private Integer commentCount;
+    private Long categoryId;
 
     public PostDetailResponse(PostGetDetailResult postDetail) {
         this.id = postDetail.getPost().getId();
@@ -21,8 +23,10 @@ public class PostDetailResponse {
         this.title = postDetail.getPost().getTitle();
         this.content = postDetail.getPost().getContent();
         this.userId = postDetail.getPost().getUserId();
+        this.nickName = postDetail.getPost().getNickName();
         this.likeFlag = postDetail.getPost().isLikeFlag();
         this.likeCount = postDetail.getPost().getLikeCount();
         this.commentCount = postDetail.getPost().getCommentCount();
+        this.categoryId = postDetail.getPost().getCategoryId();
     }
 }

--- a/groove-api/src/main/java/org/bogus/groove/endpoint/post/PostResponse.java
+++ b/groove-api/src/main/java/org/bogus/groove/endpoint/post/PostResponse.java
@@ -11,17 +11,21 @@ public class PostResponse {
     private String title;
     private String content;
     private Long userId;
+    private String nickName;
     private boolean likeFlag;
     private Integer likeCount;
     private Integer commentCount;
+    private Long categoryId;
 
     public PostResponse(PostGetResult post) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.userId = post.getUserId();
+        this.nickName = post.getNickName();
         this.likeFlag = post.isLikeFlag();
         this.likeCount = post.getLikeCount();
         this.commentCount = post.getCommentCount();
+        this.categoryId = post.getCategoryId();
     }
 }

--- a/storage/src/main/java/org/bogus/groove/storage/entity/CommentEntity.java
+++ b/storage/src/main/java/org/bogus/groove/storage/entity/CommentEntity.java
@@ -19,7 +19,7 @@ public class CommentEntity extends BaseEntity {
 
     @Column(name = "deleted_flag")
     @Setter
-    private boolean isDeleted;
+    private boolean isDeleted = false;
 
     @Column(name = "parent_id")
     private Long parentId;
@@ -30,9 +30,8 @@ public class CommentEntity extends BaseEntity {
     @Column(name = "ref_post_id")
     private Long postId;
 
-    public CommentEntity(String content, Boolean isDeleted, Long parentId, Long userId, Long postId) {
+    public CommentEntity(String content, Long parentId, Long userId, Long postId) {
         this.content = content;
-        this.isDeleted = isDeleted;
         this.parentId = parentId;
         this.userId = userId;
         this.postId = postId;

--- a/storage/src/main/java/org/bogus/groove/storage/entity/PostEntity.java
+++ b/storage/src/main/java/org/bogus/groove/storage/entity/PostEntity.java
@@ -23,15 +23,15 @@ public class PostEntity extends BaseEntity {
 
     @Column(name = "deleted_flag")
     @Setter
-    private boolean isDeleted;
+    private boolean isDeleted = false;
 
     @Column(name = "like_count")
     @Setter
-    private Integer likeCount;
+    private Integer likeCount = 0;
 
     @Column(name = "comment_count")
     @Setter
-    private Integer commentCount;
+    private Integer commentCount = 0;
 
     @Column(name = "ref_user_id")
     private Long userId;
@@ -40,12 +40,10 @@ public class PostEntity extends BaseEntity {
     @Setter
     private Long categoryId;
 
-    public PostEntity(String title, String content, boolean isDeleted,
-                      Long userId, Long categoryId) {
+    public PostEntity(String title, String content, Long userId, Long categoryId) {
         super();
         this.title = title;
         this.content = content;
-        this.isDeleted = isDeleted;
         this.userId = userId;
         this.categoryId = categoryId;
     }

--- a/storage/src/main/java/org/bogus/groove/storage/repository/PostRepositoryImpl.java
+++ b/storage/src/main/java/org/bogus/groove/storage/repository/PostRepositoryImpl.java
@@ -46,7 +46,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     private BooleanBuilder allCheck(Long categoryId, String word) {
-        return categoryEq(categoryId).and(wordSearch(word));
+        QPostEntity post = QPostEntity.postEntity;
+        return categoryEq(categoryId).and(wordSearch(word)).and(post.isDeleted.eq(Boolean.FALSE));
     }
 
     private OrderSpecifier<?> sort(Pageable pageable) {


### PR DESCRIPTION
- 게시글 댓글 추가/삭제, 좋아요/ 좋아요 취소 시 postEntity의 commentCount, likeCount값 적용되게 수정
- 게시글 삭제시 해당 게시글의 댓글 삭제되게, 댓글 삭제시 해당 댓글의 대댓글 삭제 되게끔 수정