### PR TITLE
fix: 이메일 템플릿 못찾는 문제 수정

### DIFF
--- a/mail/src/main/java/org/bogus/groove/mail/config/GoogleMailSender.java
+++ b/mail/src/main/java/org/bogus/groove/mail/config/GoogleMailSender.java
@@ -1,12 +1,10 @@
 package org.bogus.groove.mail.config;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +15,10 @@ import org.bogus.groove.common.exception.InternalServerException;
 import org.bogus.groove.object_storage.ObjectUriMaker;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.util.FileCopyUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +36,9 @@ public class GoogleMailSender {
 
     @Value("${reset-password-path}")
     private String resetPasswordPath;
+
+    @Value("classpath:authentication-template.htm")
+    private Resource emailAuthenticationTemplate;
 
     public void sendMessage(String to, String sessionKey, EmailType type) {
         if (EmailType.EMAIL_AUTHENTICATION.equals(type)) {
@@ -87,14 +90,9 @@ public class GoogleMailSender {
 
     private String getAuthenticationHtml(String sessionKey) throws IOException {
         ClassPathResource resource = new ClassPathResource("authentication-template.htm");
-        Path path = Paths.get(resource.getURI());
-        List<String> content = Files.readAllLines(path);
 
-        StringBuilder sb = new StringBuilder();
-        content.forEach(sb::append);
-        String html = sb.toString();
-
-        html = html.replaceAll("\\{\\{authenticationLink}}", getAuthenticationUrl(sessionKey));
+        var html = FileCopyUtils.copyToString(new BufferedReader(new InputStreamReader(resource.getInputStream())));
+        html = html.replace("{{authenticationLink}}", getAuthenticationUrl(sessionKey));
         html = html.replace("{{logoUrl}}", getLogoUrl());
 
         return html;


### PR DESCRIPTION
```
2023-02-11 22:58:02.651  INFO 1 --- [nio-9090-exec-2] o.b.groove.mail.config.GoogleMailSender  : template source: jar:file:/api/libs/groove-api.jar!/BOOT-INF/lib/mail-plain.jar!/authentication-template.htm
2023-02-11 22:58:02.753 ERROR 1 --- [nio-9090-exec-2] o.b.g.endpoint.SystemControllerAdvice    : 메일 발송에 실패했습니다. : {}

java.nio.file.FileSystemNotFoundException: null
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.getFileSystem(ZipFileSystemProvider.java:169) ~[jdk.zipfs:na]
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.getPath(ZipFileSystemProvider.java:155) ~[jdk.zipfs:na]
	at java.base/java.nio.file.Path.of(Path.java:208) ~[na:na]
	at java.base/java.nio.file.Paths.get(Paths.java:97) ~[na:na]
	at org.bogus.groove.mail.config.GoogleMailSender.getAuthenticationHtml(GoogleMailSender.java:92) ~[mail-plain.jar!/:na]
	at org.bogus.groove.mail.config.GoogleMailSender.emailAuthenticationMessage(GoogleMailSender.java:77) ~[mail-plain.jar!/:na]
	at org.bogus.groove.mail.config.GoogleMailSender.sendMessage(GoogleMailSender.java:42) ~[mail-plain.jar!/:na]
	at org.bogus.groove.domain.user.UserService.sendAuthenticationMail(UserService.java:44) ~[auth-plain.jar!/:na]
	at org.bogus.groove.domain.user.UserService.register(UserService.java:37) ~[auth-plain.jar!/:na]
	at org.bogus.groove.domain.user.UserService$$FastClassBySpringCGLIB$$7cbb83d.invoke(<generated>) ~[auth-plain.jar!/:na]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.19.jar!/:5.3.19]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.19.jar!/:5.3.19]

...
```

`Path`는 파일의 URI로 파일을 찾아오는데, jar 안에 있는 파일을 찾아오는 데에는 뭔가 문제가 있는 것 같고,
스프링의 `ClassPathResource`에서는 `ClassLoader`로 어떻게 잘 가져오는 것 같음
